### PR TITLE
Corrected typos on tutorial, added correct folder names to js/css links

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,8 +164,8 @@ First add a form to the public/index.html file.
 ```
 <h1> Enter A New Poki</h1>
 <form id="newPoki" ng-submit="addPoki()">
-  Name: <input type="text" ng-model="Name"> value=""><br>
-  Url: <input type="url" ng-model="Url"> value=""><br>
+  Name: <input type="text" ng-model="Name" value=""><br>
+  Url: <input type="url" ng-model="Url" value=""><br>
   <input type="submit" value="Submit">
 </form>
 ```

--- a/src/index.html
+++ b/src/index.html
@@ -2,8 +2,8 @@
 <html>
 <head>
 <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.4.0/angular.min.js"></script>
-<script src="./app.js"></script>
-<link rel="stylesheet" type="text/css" href="./style.css">
+<script src="./javascripts/app.js"></script>
+<link rel="stylesheet" type="text/css" href="./stylesheets/style.css">
   <meta charset="utf-8">
   <title>Node api tutorial</title>
 </head>


### PR DESCRIPTION
Following the tutorial, one of the code samples had incorrect html. Also, previous tutorial statements required that js/css go in subfolders called javascripts and stylesheets in the public/ directory. I updated the links in the base index.html to reflect these things.
